### PR TITLE
Make CToSMessage read the sender's username on the server

### DIFF
--- a/main/java/com/draco18s/artifacts/network/CToSMessage.java
+++ b/main/java/com/draco18s/artifacts/network/CToSMessage.java
@@ -22,7 +22,7 @@ public class CToSMessage implements IMessage {
 	
 	public CToSMessage() 
 	{
-		this(new byte[0]);
+		//Used internally on the server by Netty. Don't call client-side code here.
 	}
 
 	public CToSMessage(ByteBuf dataToSet)
@@ -37,8 +37,7 @@ public class CToSMessage implements IMessage {
         {
             throw new IllegalArgumentException("Payload may not be larger than 2097136 (0x1ffff0) bytes");
         }
-        
-        playerName = Minecraft.getMinecraft().thePlayer.getCommandSenderName();
+
         this.data = dataToSet;
 
     }
@@ -54,11 +53,6 @@ public class CToSMessage implements IMessage {
         {
             throw new IllegalArgumentException("Payload may not be larger than 2097136 (0x1ffff0) bytes");
         }
-		
-		buffer.writeInt(this.playerName.length());
-		for(int i = 0; i < this.playerName.length(); i++) {
-			buffer.writeChar(this.playerName.charAt(i));
-		}
         buffer.writeShort(this.data.length);
         buffer.writeBytes(this.data);
 	}
@@ -70,12 +64,6 @@ public class CToSMessage implements IMessage {
 	@Override
 	public void fromBytes(ByteBuf buffer) {
 //		System.out.println("Decoding");
-		
-		int nameLength = buffer.readInt();
-		this.playerName = "";
-		for(int i = 0; i < nameLength; i++) {
-			playerName += buffer.readChar();
-		}
 		this.data = new byte[buffer.readShort()];
         buffer.readBytes(this.data);
 	}
@@ -86,6 +74,10 @@ public class CToSMessage implements IMessage {
 	
 	public String getPlayerName() {
 		return this.playerName;
+	}
+	
+	public void setPlayerName(String name){
+		this.playerName=name;
 	}
 
 }

--- a/main/java/com/draco18s/artifacts/network/PacketHandlerServer.java
+++ b/main/java/com/draco18s/artifacts/network/PacketHandlerServer.java
@@ -177,7 +177,7 @@ public class PacketHandlerServer implements IMessageHandler<CToSMessage,IMessage
 						int ix = movingobjectposition.blockX;
 						int iy = movingobjectposition.blockY;
 						int iz = movingobjectposition.blockZ;
-						if (!world.getBlock(ix, iy, iz).isBlockNormalCube())
+						if (!world.getBlock(ix, iy, iz).isNormalCube())
 						{
 							--iy;
 						}

--- a/main/java/com/draco18s/artifacts/network/PacketHandlerServer.java
+++ b/main/java/com/draco18s/artifacts/network/PacketHandlerServer.java
@@ -76,6 +76,8 @@ public class PacketHandlerServer implements IMessageHandler<CToSMessage,IMessage
 	@Override
 	public IMessage onMessage(CToSMessage packet, MessageContext context)
 	{
+		packet.setPlayerName(context.getServerHandler().playerEntity.getCommandSenderName());
+		
 //		System.out.println("Caught a packet " + packet.getData() + " for player " + packet.getUUID());
 
 		ByteBuf buff = Unpooled.wrappedBuffer(packet.getData());


### PR DESCRIPTION
This removes the client-side-only Minecraft.class dependency from the packet decoding, so it won't kick players when the packet decoding errors. The problem only happened when someone uses an artifact power requiring a special packet to activate, but otherwise the server would work.

Incidentally, by reading the sender's username from the MessageContext instead of the packet data, it cuts down on both the opportunity for cheating and network chatter.